### PR TITLE
Save all buffers before compiling (and some other sbt actions)

### DIFF
--- a/src/main/elisp/ensime-builder.el
+++ b/src/main/elisp/ensime-builder.el
@@ -24,6 +24,7 @@
   "Start the incremental builder. This command will trigger
 a full recompile of the entire project!"
   (interactive)
+  (when ensime-save-before-compile (save-some-buffers))
   (setf (ensime-builder-changed-files (ensime-connection)) nil)
   (ensime-rpc-async-builder-init 'ensime-show-compile-result-buffer))
 
@@ -44,6 +45,7 @@ with all others that have been saved(modified) since the last rebuild."
 all files that have been changed since the last rebuild, so incremental
 builder can avoid extra work."
   (interactive)
+  (when ensime-save-before-compile (save-some-buffers))
   (let ((change-set (ensime-builder-changed-files
 		     (ensime-connection))))
     (if change-set

--- a/src/main/elisp/ensime-sbt.el
+++ b/src/main/elisp/ensime-sbt.el
@@ -221,20 +221,25 @@
   (interactive (list (read-string "Sbt command: " ensime-sbt-command-history)))
   (setq ensime-sbt-command-history sbt-command)
   (ensime-sbt-switch)
+  ;; Assume that any SBT action would be affected by unsaved buffers.
+  (when ensime-save-before-compile (save-some-buffers))
   (ensime-sbt-action sbt-command))
 
 (defun ensime-sbt-do-compile ()
   (interactive)
+  (when ensime-save-before-compile (save-some-buffers))
   (ensime-sbt-switch)
   (ensime-sbt-action "compile"))
 
 (defun ensime-sbt-do-clean ()
   (interactive)
+  (when ensime-save-before-compile (save-some-buffers))
   (ensime-sbt-switch)
   (ensime-sbt-action "clean"))
 
 (defun ensime-sbt-do-package ()
   (interactive)
+  (when ensime-save-before-compile (save-some-buffers))
   (ensime-sbt-switch)
   (ensime-sbt-action "package"))
 

--- a/src/main/elisp/ensime.el
+++ b/src/main/elisp/ensime.el
@@ -84,6 +84,11 @@
   :type 'boolean
   :group 'ensime-ui)
 
+(defcustom ensime-save-before-compile t
+  "If non-nil, save all buffers before compiling."
+  :type 'boolean
+  :group 'ensime-ui)
+
 (defcustom ensime-tooltip-hints t
   "If non-nil, mouse tooltips are activated."
   :type 'boolean


### PR DESCRIPTION
I thought it would be nice if emacs prompted to save all buffers before compiling (with ensime-builder or sbt)

Do you think it's ok to set ensime-save-before-compile to t by default, or should it be false to preserve the current behavior?
