### PR TITLE
Fix position of zero-length overlays.

### DIFF
--- a/src/main/elisp/ensime.el
+++ b/src/main/elisp/ensime.el
@@ -2274,7 +2274,7 @@ any buffer visiting the given file."
 
       ;; No empty note overlays!
       (when (eq beg end)
-        (setq beg (- beg 1)))
+        (setq end (+ end 1)))
 
       (let ((lang
              (cond


### PR DESCRIPTION
I noticed that when a compile error has its begin and end offsets identical, the current behavior (subtract 1 from "beg") causes whitespace to be highlighted. That makes the error invisible if the default highlight fase is used. Adding 1 to "end" does the right thing in every case I tried.
