### PR TITLE
Use ensime root-dir to find the sbt project path

### DIFF
--- a/src/main/elisp/ensime-sbt.el
+++ b/src/main/elisp/ensime-sbt.el
@@ -251,7 +251,7 @@
 
 (defun ensime-sbt-parent-path (path)
   "The parent path for the given path."
-  (file-truename (concat path "/..")))
+  (file-name-as-directory (file-truename (concat path "/.."))))
 
 (defun ensime-sbt-find-path-to-project ()
   "Move up the directory tree for the current buffer
@@ -259,10 +259,13 @@
  is found."
   (interactive)
   (let ((fn (buffer-file-name)))
-    (let ((path (file-name-directory fn)))
+    (let ((path (file-name-directory fn))
+          (project-root (file-name-as-directory
+                         (file-truename (ensime-configured-project-root)))))
       (while (and (not (ensime-sbt-project-dir-p path))
+                  (not (equal project-root path))
 		  (not (ensime-sbt-at-root path)))
-	(setf path (file-truename (ensime-sbt-parent-path path))))
+	(setf path (ensime-sbt-parent-path path)))
       path)))
 
 (defun ensime-sbt-find-path-to-parent-project ()


### PR DESCRIPTION
I have a couple more pull requests...

If the sbt root-dir auto-detection doesn't work (for instance if there's not .sbt file in the root dir), we get dumped into "/". To prevent that I added a comparison with ensime's idea of the root dir.

Questions:
1) would it make sense to always use ensime-configured-project-root instead of guessing?
2) If not, would it be better for ensime-sbt to prompt for a directory (with the result of ensime-sbt-find-path-to-project as default)?
