### PR TITLE
Fix a few more problems with external offsets in DOS mode

### DIFF
--- a/src/main/elisp/ensime-semantic-highlight.el
+++ b/src/main/elisp/ensime-semantic-highlight.el
@@ -65,8 +65,8 @@
       (with-current-buffer buf
 	(dolist (sym syms)
 	  (let* ((type (nth 0 sym))
-		 (start (+ ensime-ch-fix (nth 1 sym)))
-		 (end (+ ensime-ch-fix (nth 2 sym)))
+		 (start (ensime-internalize-offset (nth 1 sym)))
+		 (end (ensime-internalize-offset (nth 2 sym)))
 		 (face (cdr (assoc type ensime-sem-high-faces))))
 	    (let ((ov (make-overlay start end buf)))
 	      (overlay-put ov 'face face)

--- a/src/main/elisp/ensime.el
+++ b/src/main/elisp/ensime.el
@@ -614,6 +614,7 @@ argument is supplied) is a .scala or .java file."
              (posn-point (event-end event)))
 
     (let* ((point (posn-point (event-end event)))
+           (external-pos (ensime-externalize-offset point))
            (ident (tooltip-identifier-from-point point))
            (note-overlays (ensime-overlays-at point))
            (val-at-pt (ensime-db-tooltip point)))
@@ -636,7 +637,7 @@ argument is supplied) is a .scala or .java file."
        ((and ident ensime-tooltip-type-hints)
         (progn
           (ensime-eval-async
-           `(swank:type-at-point ,buffer-file-name ,point)
+           `(swank:type-at-point ,buffer-file-name ,external-pos)
            #'(lambda (type)
                (when type
                  (let ((msg (ensime-type-full-name-with-args type)))


### PR DESCRIPTION
I found a few more places where ensime-internalize-offset wasn't being used.
