### PR TITLE
Build manager no longer discards compilation notes

### DIFF
--- a/src/main/scala/org/ensime/util/Reporter.scala
+++ b/src/main/scala/org/ensime/util/Reporter.scala
@@ -27,10 +27,9 @@
 
 package org.ensime.util
 
-import scala.collection.mutable.{ HashEntry, HashMap, HashSet, SynchronizedMap }
 import scala.tools.nsc.interactive.CompilerControl
 import scala.tools.nsc.reporters.{ ConsoleReporter, Reporter }
-import scala.tools.nsc.util.{ OffsetPosition, Position, SourceFile }
+import scala.tools.nsc.util.{ OffsetPosition, Position }
 
 trait ReportHandler {
   def messageUser(str: String) {}
@@ -44,19 +43,12 @@ trait ReportHandler {
 
 class PresentationReporter(handler: ReportHandler) extends Reporter {
 
-  private val notes = new HashMap[SourceFile, HashSet[Note]] with SynchronizedMap[SourceFile, HashSet[Note]] {
-    override def default(k: SourceFile) = { val v = new HashSet[Note]; put(k, v); v }
-  }
-
-  def allNotes: Iterable[Note] = notes.flatMap { e => e._2 }.toList
-
   private var enabled = true
   def enable() { enabled = true }
   def disable() { enabled = false }
 
   override def reset {
     super.reset
-    notes.clear
     if(enabled){
       handler.clearAllScalaNotes()
     }


### PR DESCRIPTION
Currently, "Build project" always prints "0 errors, 0 warnings" because notes are just thrown away by the default ReportHandler.
